### PR TITLE
feat: add optional timezone per maintenance window

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ windows:
                               #       used to make the "maintenance window" 
                               #       unique.
     cron: "0 12 * * 0"
+    timezone: UTC             # This maintenance window follows UTC instead of
+                              # the global "Europe/Amsterdam" configuration.
     duration: 2h
     labels:
       component: bar
@@ -61,8 +63,8 @@ windows:
 The metrics would then look like this:
 ```console
 > curl http://localhost:9099/metrics
-maintenance_active{component="bar",name="restore staging"} 0
-maintenance_active{component="foo",name="restore staging"} 0
+maintenance_active{component="bar",name="restore staging",configured_timezone="UTC"} 0
+maintenance_active{component="foo",name="restore staging",configured_timezone="Europe/Amsterdam"} 0
 ```
 
 

--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -20,8 +20,10 @@ windows:
     labels: {}
 
   - name: testy mctestface
-    cron: "* * * * *"
+    cron: "* 2 * * *"
     duration: 30s
+    timezone: UTC             # Default: config.timezone. This window timezone 
+                              # follows UTC
     labels:
       service_level: development
 

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
-github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=
-github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/go-co-op/gocron/v2 v2.16.1 h1:ux/5zxVRveCaCuTtNI3DiOk581KC1KpJbpJFYUEVYwo=
@@ -43,8 +41,6 @@ github.com/spf13/cast v1.7.1 h1:cuNEagBQEHWN1FnbGEjCXL2szYEXqfJPbP2HNUaca9Y=
 github.com/spf13/cast v1.7.1/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
 github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
 github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-github.com/spf13/viper v1.20.0 h1:zrxIyR3RQIOsarIrgL8+sAvALXul9jeEPa06Y0Ph6vY=
-github.com/spf13/viper v1.20.0/go.mod h1:P9Mdzt1zoHIG8m2eZQinpiBjo6kCmZSKBClNNqjJvu4=
 github.com/spf13/viper v1.20.1 h1:ZMi+z/lvLyPSCoNtFCpqjy0S4kPbirhpTMwl8BkW9X4=
 github.com/spf13/viper v1.20.1/go.mod h1:P9Mdzt1zoHIG8m2eZQinpiBjo6kCmZSKBClNNqjJvu4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
This PR adds an optional timezone definition in the maintenance window configuration.

Metrics now contain a default label `configured_timezone` reflecting the configured timezone for each maintenance window.

A configuration with a timezone definition would look like this:
```yaml
windows:
  - name: testy mctestface
    cron: "* 2 * * *"
    duration: 30s
    timezone: UTC             # Default: config.timezone. This window timezone
                                           # follows UTC
    labels:
      service_level: development
```